### PR TITLE
Change updates and ADDs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM quay.io/informaticslab/iris
-
 MAINTAINER niall.robinson@informaticslab.co.uk
 
 RUN apt-get update
-RUN apt-get install -y git
+ && apt-get install -y git
+
 RUN git clone https://github.com/met-office-lab/cloud-processing-config.git config
 
-ADD [^.]* ./
+ADD requirements.txt requirements.txt
+ADD scheduler.py scheduler.py
 
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt


### PR DESCRIPTION
`apt-get update` only updates the source repo lists so it may as well be included in the install line.

`ADD [^.]* .` seems bad and I've removed it from mine. As you only have two files it makes sense to include them manually.

I also suggest you move the `pip update pip` line to the parent image and remove it form here. But I haven't done that in this PR.